### PR TITLE
Fix bug where non-existing days had 1 hour wear time

### DIFF
--- a/OnTheWrist/ContentView.swift
+++ b/OnTheWrist/ContentView.swift
@@ -99,14 +99,14 @@ class WristCheck: ObservableObject {
                             let new = (worn:existingHour.worn + (exists ? 1 : 0), total: existingHour.total + 1)
                             hours[hourKey] = new
                         } else {
-                            hours[hourKey] = (worn:1, total:1)
+                            hours[hourKey] = (worn:exists ? 1 : 0, total:1)
                         }
                         
                         if let existingDay = days[dayKey] {
                             let new = (worn:existingDay.worn + (exists ? 1 : 0), total: existingDay.total + 1)
                             days[dayKey] = new
                         } else {
-                            days[dayKey] = (worn:1, total:1)
+                            days[dayKey] = (worn:exists ? 1 : 0, total:1)
                         }
                         
                     }


### PR DESCRIPTION
I set the starting time back one year and obviously I didn't wear the watch then, but I got results like

```
Daily Data
2014-04-24	4.0	1	24
2014-04-25	4.0	1	24
2014-04-26	4.0	1	24
2014-04-27	4.0	1	24
...
```

I guess that for non-existing days the start value for `worn` should not be 1 but 0:

```
Daily Data
2014-04-24	0.0	0	24
2014-04-25	0.0	0	24
2014-04-26	0.0	0	24
2014-04-27	0.0	0	24
```